### PR TITLE
Adds timezone param to Janus request

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,5 +4,7 @@ version := "0.2.2"
 
 libraryDependencies ++= Seq(
   "org.seleniumhq.selenium" % "selenium-java" % "2.53.0",
-  "com.github.scopt" %% "scopt" % "3.3.0"
+  "com.github.scopt" %% "scopt" % "3.3.0",
+  "joda-time" % "joda-time" % "2.9.3",
+  "org.joda" % "joda-convert" % "1.8"
 )

--- a/src/main/scala/feria/Feria.scala
+++ b/src/main/scala/feria/Feria.scala
@@ -1,14 +1,13 @@
 package feria
 
+import org.joda.time.{DateTime, DateTimeZone}
 import org.openqa.selenium._
 import org.openqa.selenium.firefox._
 import org.openqa.selenium.firefox.internal._
-
 import scopt._
 
-import scala.collection.JavaConverters._
-import scala.util._
 import scala.sys.process._
+import scala.util._
 
 case class Config(profile: String = "", access: String = "dev")
 
@@ -41,8 +40,9 @@ object Feria extends App {
     }
 
     try {
-      val permissionId = s"${config.profile}-${config.access}"  
-      driver.get(s"https://janus.gutools.co.uk/credentials?permissionId=$permissionId")
+      val permissionId = s"${config.profile}-${config.access}"
+      val timeZoneOffset = DateTimeZone.getDefault.getOffset(DateTime.now) / 3600000
+      driver.get(s"https://janus.gutools.co.uk/credentials?permissionId=$permissionId&tzOffset=$timeZoneOffset")
       // If you are signed in to multiple accounts you will be redirected to an 'Account Chooser' page
       if (driver.getCurrentUrl.contains("AccountChooser"))
           driver.findElementByXPath("//button[contains(@value,'guardian.co.uk')]").click()


### PR DESCRIPTION
As of https://github.com/guardian/janus/pull/270, Janus expects a timezone parameter. It uses this to give users sensible session times. Without it you get the default, but with it you'll get until "7pm local time" unless it's nearly 7pm. This stops devs having problems when e.g. they get in early and work for more than 8hrs.

I don't use Firefox so I've not actually tested this...
