### PR TITLE
Fix bug when running from other directories

### DIFF
--- a/bin/feria
+++ b/bin/feria
@@ -10,4 +10,6 @@ if [ ! -e "$jar" ]; then
   popd
 fi
 
+pushd $basedir
 java -jar $jar "$@"
+popd


### PR DESCRIPTION
The path to geckodriver is relative to feria, this ensures it's always run from the right place. 
